### PR TITLE
Feedback

### DIFF
--- a/average.js
+++ b/average.js
@@ -1,5 +1,6 @@
+
 function average(numbers) {
-  var filtered = numbers.filter(number => !(isNaN(number)));
+  var filtered = numbers.filter(number => !(isNaN(number)) && (number >= -5) && (number <= 60));
   
   if(filtered.length == 0)
     return NaN;

--- a/average.js
+++ b/average.js
@@ -1,6 +1,7 @@
 
 function average(numbers) {
-  var filtered = numbers.filter(number => !(isNaN(number)) && (number >= -5) && (number <= 60));
+  var filtered = numbers.filter(number => !(isNaN(number)));
+  filtered = numbers.filter(number => (number >= -5) && (number <= 60));
   
   if(filtered.length == 0)
     return NaN;

--- a/test/average.test.js
+++ b/test/average.test.js
@@ -15,7 +15,7 @@ it('ignores NaN in the input', ()=> {
   expect(average([1, NaN, 2])).to.be.approximately(1.5, 0.01);
 });
 
-//assuming thresholds for battery operation when battery_temp> 5 deg C and battery_temp<45 deg C
+//assuming thresholds for battery opn. when temp> 5 deg C and temp<45 deg C
 it('ingores outliers in the input which are outside the thresholds',()=> {
   expect(average([6,-3,10,50])).to.be.approximately(8, 0.01);;
 });

--- a/test/average.test.js
+++ b/test/average.test.js
@@ -14,3 +14,8 @@ it('reports the average as NaN on an empty list', ()=> {
 it('ignores NaN in the input', ()=> {
   expect(average([1, NaN, 2])).to.be.approximately(1.5, 0.01);
 });
+
+//assuming thresholds for battery operation when battery_temp> 5 deg C and battery_temp<45 deg C
+it('ingores outliers in the input which are outside the thresholds',()=> {
+  expect(average([6,-3,10,50])).to.be.approximately(8, 0.01);;
+});

--- a/test/average.test.js
+++ b/test/average.test.js
@@ -1,6 +1,11 @@
 const {expect} = require('chai');
 const {average} = require('../average');
 
+//assuming thresholds for battery opn. when temp> -5 deg C and temp<60 deg C
+it('ignores outliers in the input which are outside the thresholds',()=> {
+  expect(average([7,-50,8,80])).to.be.approximately(7.5, 0.01);;
+});
+
 it('computes average of a list of numbers', ()=> {
   // floating point numbers cannot be compared for equality,
   // hence allowing a delta tolerance
@@ -13,9 +18,4 @@ it('reports the average as NaN on an empty list', ()=> {
 
 it('ignores NaN in the input', ()=> {
   expect(average([1, NaN, 2])).to.be.approximately(1.5, 0.01);
-});
-
-//assuming thresholds for battery opn. when temp> -5 deg C and temp<60 deg C
-it('ignores outliers in the input which are outside the thresholds',()=> {
-  expect(average([7,-50,8,80])).to.be.approximately(7.5, 0.01);;
 });

--- a/test/average.test.js
+++ b/test/average.test.js
@@ -15,7 +15,7 @@ it('ignores NaN in the input', ()=> {
   expect(average([1, NaN, 2])).to.be.approximately(1.5, 0.01);
 });
 
-//assuming thresholds for battery opn. when temp> 5 deg C and temp<45 deg C
+//assuming thresholds for battery opn. when temp> -5 deg C and temp<60 deg C
 it('ignores outliers in the input which are outside the thresholds',()=> {
-  expect(average([7,-3,8,50])).to.be.approximately(7.5, 0.01);;
+  expect(average([7,-50,8,80])).to.be.approximately(7.5, 0.01);;
 });

--- a/test/average.test.js
+++ b/test/average.test.js
@@ -16,6 +16,6 @@ it('ignores NaN in the input', ()=> {
 });
 
 //assuming thresholds for battery opn. when temp> 5 deg C and temp<45 deg C
-it('ingores outliers in the input which are outside the thresholds',()=> {
-  expect(average([6,-3,10,50])).to.be.approximately(8, 0.01);;
+it('ignores outliers in the input which are outside the thresholds',()=> {
+  expect(average([7,-3,8,50])).to.be.approximately(7.5, 0.01);;
 });


### PR DESCRIPTION
Implementing functionality to include input only when within threshold limits. The battery threshold limits are set to [-5,+60] deg Centigrade.